### PR TITLE
Hide highlight

### DIFF
--- a/README.AKASA.md
+++ b/README.AKASA.md
@@ -7,6 +7,8 @@ Akasa maintains a small fork of the [Playwright](https://github.com/microsoft/pl
 
 ## Changes
 
+* **1.35.2-akasa1**: Expose the hideHighlight option in `BrowserContext.enableRecorder` so that we can toggle the highlight view showing during user actions. (mjeti, September 2023)
+
 * **1.35.1-akasa1**: Expose `BrowserContext.enableRecorder` so that we can initiate recordings programmatically. (masoncj, June 2023)
 
 ## Release process

--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -1612,6 +1612,14 @@ Will throw an error if the browser context is closed before the `event` is fired
 
 Enables code generation recorder.
 
+
+### param: BrowserContext.enableRecorder.hideHighlight
+* since: v1.35
+* langs: python
+- `hideHighlight` <[boolean]>
+
+Toggle the highlight view for user actions when recording
+
 ### param: BrowserContext.enableRecorder.language
 * since: v1.35
 * langs: python

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "playwright-internal",
   "private": true,
-  "version": "1.35.1-akasa1",
+  "version": "1.35.2-akasa1",
   "description": "A high-level API to automate web browsers",
   "repository": "github:Microsoft/playwright",
   "homepage": "https://playwright.dev",

--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -406,7 +406,7 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
       testIdAttributeName?: string,
       outputFile?: string,
       handleSIGINT?: boolean,
-      highlight?: boolean,
+      hideHighlight?: boolean,
   }) {
     await this._channel.recorderSupplementEnable(params);
   }

--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -406,6 +406,7 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
       testIdAttributeName?: string,
       outputFile?: string,
       handleSIGINT?: boolean,
+      highlight?: boolean,
   }) {
     await this._channel.recorderSupplementEnable(params);
   }

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -886,6 +886,7 @@ scheme.BrowserContextPauseResult = tOptional(tObject({}));
 scheme.BrowserContextRecorderSupplementEnableParams = tObject({
   language: tOptional(tString),
   mode: tOptional(tEnum(['inspecting', 'recording'])),
+  hideHighlight: tOptional(tBoolean),
   pauseOnNextStatement: tOptional(tBoolean),
   testIdAttributeName: tOptional(tString),
   launchOptions: tOptional(tAny),

--- a/packages/playwright-core/src/server/injected/recorder.ts
+++ b/packages/playwright-core/src/server/injected/recorder.ts
@@ -42,12 +42,14 @@ export class Recorder {
   private _testIdAttributeName: string = 'data-testid';
   readonly document: Document;
   private _delegate: RecorderDelegate;
+  private _showHighlight: boolean;
 
   constructor(injectedScript: InjectedScript, delegate: RecorderDelegate, showHighlight: boolean) {
     this.document = injectedScript.document;
     this._injectedScript = injectedScript;
     this._delegate = delegate;
-    this._highlight = showHighlight ? new Highlight(injectedScript) : null;
+    this._highlight = new Highlight(injectedScript);
+    this._showHighlight = showHighlight;
 
     this.refreshListenersIfNeeded();
 
@@ -57,7 +59,7 @@ export class Recorder {
 
   refreshListenersIfNeeded() {
     // Ensure we are attached to the current document, and we are on top (last element);
-    if (!this._highlight || this._highlight.isInstalled())
+    if (this._highlight?.isInstalled())
       return;
     removeEventListeners(this._listeners);
     this._listeners = [
@@ -75,15 +77,21 @@ export class Recorder {
         if (!event.isTrusted)
           return;
         this._hoveredModel = null;
-        this._highlight?.hideActionPoint();
-        this._updateHighlight();
+        if (this._showHighlight) {
+          this._highlight?.hideActionPoint();
+          this._updateHighlight();
+        }
       }, true),
     ];
     this._highlight?.install();
   }
 
   setUIState(state: UIState) {
-    const { mode, actionPoint, actionSelector, language, testIdAttributeName } = state;
+    const { mode, actionPoint, showHighlight, actionSelector, language, testIdAttributeName } = state;
+    if (!showHighlight) {
+      this._highlight?.updateHighlight([], '', false)
+    }
+    this._showHighlight = showHighlight;
     this._testIdAttributeName = testIdAttributeName;
     this._highlight?.setLanguage(language);
     if (mode !== this._mode) {
@@ -94,7 +102,7 @@ export class Recorder {
       // All good.
     } else if (!actionPoint && !this._actionPoint) {
       // All good.
-    } else {
+    } else if (this._showHighlight) {
       if (actionPoint)
         this._highlight?.showActionPoint(actionPoint.x, actionPoint.y);
       else
@@ -266,7 +274,9 @@ export class Recorder {
   private _updateHighlight() {
     const elements = this._hoveredModel ? this._hoveredModel.elements : [];
     const selector = this._hoveredModel ? this._hoveredModel.selector : '';
-    this._highlight?.updateHighlight(elements, selector, this._mode === 'recording');
+    if (this._showHighlight) {
+      this._highlight?.updateHighlight(elements, selector, this._mode === 'recording');
+    }
   }
 
   private _onInput(event: Event) {
@@ -494,7 +504,7 @@ export class PollingRecorder implements RecorderDelegate {
   private _pollRecorderModeTimer: NodeJS.Timeout | undefined;
 
   constructor(injectedScript: InjectedScript) {
-    this._recorder = new Recorder(injectedScript, this, showHighlight);
+    this._recorder = new Recorder(injectedScript, this, true);
     this._embedder = injectedScript.window as any;
 
     injectedScript.onGlobalListenersRemoved.add(() => this._recorder.refreshListenersIfNeeded());

--- a/packages/playwright-core/src/server/recorder.ts
+++ b/packages/playwright-core/src/server/recorder.ts
@@ -53,6 +53,7 @@ const recorderSymbol = Symbol('recorderSymbol');
 export class Recorder implements InstrumentationListener {
   private _context: BrowserContext;
   private _mode: Mode;
+  private _showHighlight: boolean;
   private _highlightedSelector = '';
   private _recorderApp: IRecorderApp | null = null;
   private _currentCallsMetadata = new Map<CallMetadata, SdkObject>();
@@ -88,6 +89,7 @@ export class Recorder implements InstrumentationListener {
     this._mode = params.mode || 'none';
     this._contextRecorder = new ContextRecorder(context, params);
     this._context = context;
+    this._showHighlight = !params.hideHighlight;
     this._omitCallTracking = !!params.omitCallTracking;
     this._debugger = context.debugger();
     this._handleSIGINT = params.handleSIGINT;
@@ -175,6 +177,7 @@ export class Recorder implements InstrumentationListener {
         actionPoint,
         actionSelector,
         language: this._currentLanguage,
+        showHighlight: this._showHighlight,
         testIdAttributeName: this._contextRecorder.testIdAttributeName(),
       };
       return uiState;

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -1629,6 +1629,7 @@ export type BrowserContextRecorderSupplementEnableParams = {
   outputFile?: string,
   handleSIGINT?: boolean,
   omitCallTracking?: boolean,
+  hideHighlight?: boolean,
 };
 export type BrowserContextRecorderSupplementEnableOptions = {
   language?: string,

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -1620,6 +1620,7 @@ export type BrowserContextPauseResult = void;
 export type BrowserContextRecorderSupplementEnableParams = {
   language?: string,
   mode?: 'inspecting' | 'recording',
+  hideHighlight?: boolean,
   pauseOnNextStatement?: boolean,
   testIdAttributeName?: string,
   launchOptions?: any,
@@ -1629,11 +1630,11 @@ export type BrowserContextRecorderSupplementEnableParams = {
   outputFile?: string,
   handleSIGINT?: boolean,
   omitCallTracking?: boolean,
-  hideHighlight?: boolean,
 };
 export type BrowserContextRecorderSupplementEnableOptions = {
   language?: string,
   mode?: 'inspecting' | 'recording',
+  hideHighlight?: boolean,
   pauseOnNextStatement?: boolean,
   testIdAttributeName?: string,
   launchOptions?: any,

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -1113,6 +1113,7 @@ BrowserContext:
           literals:
           - inspecting
           - recording
+        hideHighlight: boolean?
         pauseOnNextStatement: boolean?
         testIdAttributeName: string?
         launchOptions: json?

--- a/packages/recorder/src/recorderTypes.ts
+++ b/packages/recorder/src/recorderTypes.ts
@@ -29,6 +29,7 @@ export type UIState = {
   mode: Mode;
   actionPoint?: Point;
   actionSelector?: string;
+  showHighlight: boolean;
   language: 'javascript' | 'python' | 'java' | 'csharp' | 'jsonl';
   testIdAttributeName: string;
 };


### PR DESCRIPTION
@mjeti CC @chase-lewis-akasa @armaghan-behlum 

Draft: only a sketch. 

Hide red highlight during browser recording to improved perceived performance.

Refs https://akasa-health.atlassian.net/browse/MARS-497

Basic idea here is to add an argument `hideHighlight` to the [`BrowserContext.recorderSupplementEnable`](https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/client/browserContext.ts#L410) call. This call (spelled `enable_recorder` in Python) is made in Director [here](https://github.com/alpha-health-ai/director/blob/master/director/src/controller_native_playwright.py#L305).  This call is sent to the Playwright server and then gets passed through to the Javascript that Playwright injects into the page to enable recording, and in `Recorder.constructor` make `_highlight` optional [here](https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/server/injected/recorder.ts#L50).

Not yet sure how to pass this argument through the call to `BrowserContext.extendInjectedScript` that happens in [`Recorder.install()`](https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/server/recorder.ts#L190).  There's also a bunch of generic RPC plumbing yet to do, that's similar to that in the earlier branches ([javascript](https://github.com/microsoft/playwright/compare/main...alpha-health-ai:playwright:akasa-expose-enable-recorder?expand=1), [python](https://github.com/microsoft/playwright-python/compare/main...alpha-health-ai:playwright-python:akasa-expose-enable-recorder?expand=1)).
